### PR TITLE
Enabling docker builds on all branches for Clever/resolve-ip

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,12 +16,18 @@ test:
   - tar xvzf GeoLiteCity_20160301.tar.gz
   - make test
 deployment:
-  all:
-    branch: master
+  master:
     owner: Clever
     commands:
     - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS resolve-ip
     - $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN gen-js/
+    branch: master
+  non-master:
+    owner: Clever
+    commands:
+    - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
+    - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS resolve-ip
+    branch: /^(?!master$).*$/
 general:
   build_dir: ../.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION

## This an automated PR

*Risk rating*: 1 clever clover :four_leaf_clover:  
*or* 0.1 oauth deploys :shipit:

So free to merge yourself

## Details:

After much discussion, it seems worthwhile to enable docker builds on all branches.  It's always been difficult to deploy development branches to dev.  Which is kinda ironic.  Don't you think? It's like ten thousands tests when all you need is a deploy.  It's like breaking the build by merging to master.  Isn't it ironic?  It's a little too ironic.  I really do think.

Once merged, you'll be able to run `ark start Clever/resolve-ip -b <branch>` on a whim.  No more "temporary" changes to [circle.yml](https://github.com/Clever/app-view-service/commit/dbcf816fd208ac42b2821b831b0297978dc6526c#diff-29944324a3cbf9f4bd0162dfe3975d88).  After this PR, you'll live in a world free of sudden master failures due to subtle Dockerfile changes.  We'll live in a world of more dev deploys and fewer flares.

Free docker images for all!

The downside?  Slower builds, but isn't freedom worth waiting for?

*Jira*: https://clever.atlassian.net/browse/INFRA-2257

### Why was I get picked?

This is how assignees were picked:

```js
function pickRandomAssignee(appInfo) {
	let team = appInfo.launch.team
	let shepherds = appInfo.launch.shepherds;
	if(shepherds && team != "{{.TeamName}}") {
		return shepherds[(Math.random() * shepherds.length) | 0];
	}

	if(team == "{{.TeamName}}") { team = "eng-infra"; }
	if(team) {
		let members = teams[team];
		return members[(Math.random() * members.length) | 0];
	}

	if(appInfo.repo == "cleverville") { return "stephanie.chen@clever.com"; }

	return "dunno-pick-manually";
}
```
