### PR TITLE
Optimize `make build` for faster local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM gliderlabs/alpine:3.3
 COPY GeoLiteCity /GeoLiteCity
 
 RUN apk-install ca-certificates
-COPY build/resolve-ip /bin/resolve-ip
+COPY bin/resolve-ip /bin/resolve-ip
 
 CMD ["/bin/resolve-ip", "--addr=0.0.0.0:80"]

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ $(PKGS): golang-test-all-strict-deps
 	$(call golang-test-all-strict,$@)
 
 build:
-	CGO_ENABLED=0 go build -installsuffix cgo -o build/$(EXECUTABLE) $(PKG)
+	$(call golang-build,$(PKG),$(EXECUTABLE))
 
 run: build
-	build/$(EXECUTABLE)
+	bin/$(EXECUTABLE)
 
 generate: wag-generate-deps
 	$(call wag-generate,./swagger.yml,$(PKG))


### PR DESCRIPTION

Context: https://github.com/Clever/dev-handbook/pull/103/

When we run `ark start --local`, it's not necessary to do a CGO build.
We only need CGO when building the go binary to put into an Alpine linux Docker image.

Doing a non-CGO build locally can decrease build times drastically, ~10x faster

_NOTE_: Assuming a passing build, unless you reject the PR, I will auto-merge after ~1 day.