### PR TITLE
[Pod Migration] eng-identity single-region services (Step 1: deployable)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Clever/eng-identity

--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -27,3 +27,9 @@ alarms:
       evaluationPeriods: 10
     extraParameters:
       requestMinimum: 100
+pod_config:
+  group: us-west-1
+  prod:
+    migrationState: deployable
+  dev:
+    migrationState: deployable

--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -1,7 +1,7 @@
 env:
 resources:
-  cpu: .25
-  max_mem: 1
+  cpu: 1.5
+  max_mem: 0.5
 expose:
   - name: http
     port: 80


### PR DESCRIPTION
JIRA: https://clever.atlassian.net/browse/ID-22

This PR is the first step in migrating eng identity's apps to pods.

It should only include migrations of
- services
- deployments to a "single region" (e.g. `us-west-1`)

A future set of PRs will handle workers, as well a multi-region.

--

`deployable` means it will be shadow deployed

  - no traffic will be routed to it
  - it cannot be discovered by other apps

--

Things to consider:

- [x] Is there any reason for this service to use a region other than `us-west-1`?
  For example, does the service connect to datastore that lives in another region (usually `us-west-2`)?
- [x] Do we need to tune the CPU for this service to make the pods deploy reliable? "In AWS Fargate CPU can't exceed 100%"
  - If there's an `sso-` version of this service, take a look at its launch YML. those are already deployed to pods and working well.
  - Otherwise, take a look at the service's metrics in `go/services` and tune as needed. See [Step #1 here](https://clever.atlassian.net/wiki/spaces/ENG/pages/1481506869/Migrating+a+Service+to+Pods)

<img width="1324" alt="Applications_-_Grafana" src="https://user-images.githubusercontent.com/102242/109345104-7ad70600-7824-11eb-8b85-d402a2c736cb.png">
