### PR TITLE
[Pod Migration] podOnly in Dev

### DIFF
--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -32,4 +32,4 @@ pod_config:
   prod:
     migrationState: deployable
   dev:
-    migrationState: discoverable
+    migrationState: podOnly


### PR DESCRIPTION

JIRA: https://clever.atlassian.net/browse/ID-22

This is Step (10) in the pod migration guide:
https://clever.atlassian.net/wiki/spaces/ENG/pages/1481506869/Migrating+a+Service+to+Pods

Once we're satisfied that `dev` is working well with `podOnly` for ~1d, we'll
make `prod` be `discoverable` to start sending traffic to it.
