### PR TITLE
prod to discoverable

### DIFF
--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -1,35 +1,35 @@
 env:
 resources:
-  cpu: 1.5
-  max_mem: 0.5
+  cpu: 2
+  max_mem: 4
 expose:
-  - name: http
-    port: 80
-    health_check:
-      type: http
-      path: /healthcheck
+- name: http
+  port: 80
+  health_check:
+    type: http
+    path: /healthcheck
 team: eng-identity
 databases: []
 alarms:
-  - type: InternalErrorAlarm
-    severity: major
-    channel: "#portal-sso-major-alerts"
-    parameters:
-      threshold: 0.01
-      evaluationPeriods: 3
-    extraParameters:
-      requestMinimum: 100
-  - type: InternalErrorAlarm
-    severity: critical
-    channel: "#oncall-portal-sso"
-    parameters:
-      threshold: 0.05
-      evaluationPeriods: 10
-    extraParameters:
-      requestMinimum: 100
+- type: InternalErrorAlarm
+  severity: major
+  channel: '#portal-sso-major-alerts'
+  parameters:
+    threshold: 0.01
+    evaluationPeriods: 3
+  extraParameters:
+    requestMinimum: 100
+- type: InternalErrorAlarm
+  severity: critical
+  channel: '#oncall-portal-sso'
+  parameters:
+    threshold: 0.05
+    evaluationPeriods: 10
+  extraParameters:
+    requestMinimum: 100
 pod_config:
-  group: us-west-1
-  prod:
-    migrationState: deployable
   dev:
     migrationState: podOnly
+  group: us-west-1
+  prod:
+    migrationState: discoverable


### PR DESCRIPTION
This PR is the third step in migrating this service to pods

This PR will make traffic from upstreams apps that are in pods go to the pod deployment in production

After merging this PR once the deploy is complete
1. `ark start --upstreams -e production <appName>`
2. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/services)

In case of errors
1. revert this PR
2. merge the deploy
3. `ark start --upstreams -e production <appName>`
