### PR TITLE
prod to podOnly

### DIFF
--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -32,4 +32,4 @@ pod_config:
     migrationState: podOnly
   group: us-west-1
   prod:
-    migrationState: discoverable
+    migrationState: podOnly


### PR DESCRIPTION
This PR is the fourth step in migrating this service to pods

This PR will make all prod traffic go to the pod deployment in production

After merging this PR once the deploy is complete
1. `ark start --upstreams -e production <appName>`
2. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/services)

In case of errors
1. revert this PR
2. merge the deploy
3. `ark start --upstreams -e production <appName>`
