### PR TITLE
Remove package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Looks like this was added accidentally. We are not able to publish go dependency files because of this