### PR TITLE
both to noHomepod

### DIFF
--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -28,8 +28,4 @@ alarms:
   extraParameters:
     requestMinimum: 100
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-1
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
This PR is the last step in migrating this service to pods

If this repo has a public DNS then contact #oncall-infra for a followup to update the load balancers for that DNS record. You check check if this repo has a public DNS by checking the launch.yml and looking for a entry for external.

Otherwise all the traffic to the service is already in pods so we are ready to stop deploying to homepod.

After merging this PR create a reminder to kill-homepod 4 days from now as we want at least 3 days to pass to confirm that absolutely no traffic is still going to the homepod deployment as sometimes we hardcode urls instead of using discovery

Homepod deployment can be killed after 3 days of no traffic by using the following command. The command will warn you if the service received unexpected traffic in homepod.
1. `ark stop <app> -e clever-dev --kill-homepod`
2. `ark stop <app> -e production --kill-homepod`

We recommend just creating slack reminders like below for all apps or one app based on your preference
/remind [@someone] ark stop <app> -e clever-dev --kill-homepod in 3 days
/remind [@someone] ark stop <app> -e production --kill-homepod in 3 days

Thanks
