### PR TITLE
migrate single-region services to app mesh in hybrid state in dev

### DIFF
--- a/launch/resolve-ip.yml
+++ b/launch/resolve-ip.yml
@@ -32,3 +32,7 @@ deploy_config:
   autoDeployEnvs:
   - clever-dev
   - production
+mesh_config:
+  dev:
+    state: hybrid
+  crossRegionRoute: sso


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5111

**Overview:**
In this PR we will migrate all internal single region services in this repo to use app mesh to hybrid state.

After this PR is merged the workers will have both envoy proxy sidecar and other appmesh constructs as well as a loadbalancers. Other services/workers have the option to use either option for making connections.

Eventually all services and workers will be restarted to make it so that all traffic comes through envoy at which point we will migrate this service to mesh_only

**Rollout:**
- monitor cpu and memory
- if upstream is in mesh then restart them so that traffic is sent using envoy
